### PR TITLE
Enhance Profile Photo Upload Experience / possible bug

### DIFF
--- a/gitjobs-server/src/handlers/img.rs
+++ b/gitjobs-server/src/handlers/img.rs
@@ -18,6 +18,12 @@ use crate::{
     img::{DynImageStore, ImageFormat},
 };
 
+/// Maximum allowed file size for image uploads (2MB)
+const MAX_FILE_SIZE: usize = 2 * 1024 * 1024;
+
+/// Supported image file extensions
+const SUPPORTED_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp", "tiff", "svg"];
+
 /// Returns an image from the store, setting headers for cache and content type.
 #[instrument(skip_all, err)]
 pub(crate) async fn get(
@@ -54,22 +60,71 @@ pub(crate) async fn upload(
 ) -> Result<impl IntoResponse, HandlerError> {
     // Get user from session
     let Some(user) = auth_session.user else {
+        tracing::warn!("Image upload attempted without authentication");
         return Ok(StatusCode::FORBIDDEN.into_response());
     };
 
+    tracing::info!("Processing image upload for user: {}", user.user_id);
+
     // Get image file name and data from the multipart form data
-    let (file_name, data) = if let Ok(Some(field)) = multipart.next_field().await {
-        let file_name = field.file_name().unwrap_or_default().to_string();
-        let Ok(data) = field.bytes().await else {
-            return Ok(StatusCode::BAD_REQUEST.into_response());
-        };
-        (file_name, data)
+    let field = match multipart.next_field().await {
+        Ok(Some(field)) => field,
+        Ok(None) => {
+            tracing::error!("No multipart field found in upload request");
+            return Ok((StatusCode::BAD_REQUEST, "No file provided").into_response());
+        }
+        Err(e) => {
+            tracing::error!("Failed to read multipart field: {}", e);
+            // This often happens when the request exceeds size limits
+            return Ok((StatusCode::PAYLOAD_TOO_LARGE, format!("File too large. Maximum size allowed is {}MB", MAX_FILE_SIZE / (1024 * 1024))).into_response());
+        }
+    };
+
+    let file_name = field.file_name().unwrap_or("unknown").to_string();
+    tracing::info!("Uploading file: {}", file_name);
+
+    // Validate file extension
+    if let Some(extension) = file_name.split('.').last() {
+        let ext_lower = extension.to_lowercase();
+        if !SUPPORTED_EXTENSIONS.contains(&ext_lower.as_str()) {
+            tracing::warn!("Unsupported file extension: {}", extension);
+            return Ok((StatusCode::BAD_REQUEST, format!("Unsupported file type. Supported formats: {}", SUPPORTED_EXTENSIONS.join(", "))).into_response());
+        }
     } else {
-        return Ok(StatusCode::BAD_REQUEST.into_response());
+        tracing::warn!("File has no extension: {}", file_name);
+        return Ok((StatusCode::BAD_REQUEST, "File must have a valid extension").into_response());
+    }
+
+    let data = match field.bytes().await {
+        Ok(data) => {
+            if data.is_empty() {
+                tracing::error!("Uploaded file is empty");
+                return Ok((StatusCode::BAD_REQUEST, "File is empty").into_response());
+            }
+            
+            if data.len() > MAX_FILE_SIZE {
+                tracing::warn!("File size {} bytes exceeds limit of {} bytes", data.len(), MAX_FILE_SIZE);
+                return Ok((StatusCode::PAYLOAD_TOO_LARGE, format!("File size {}MB exceeds maximum allowed size of {}MB", data.len() / (1024 * 1024), MAX_FILE_SIZE / (1024 * 1024))).into_response());
+            }
+            
+            tracing::info!("File size: {} bytes", data.len());
+            data
+        }
+        Err(e) => {
+            tracing::error!("Failed to read file bytes: {}", e);
+            return Ok((StatusCode::BAD_REQUEST, "Failed to read file data").into_response());
+        }
     };
 
     // Save image to store
-    let image_id = image_store.save(&user.user_id, &file_name, data.to_vec()).await?;
-
-    Ok((StatusCode::OK, image_id.to_string()).into_response())
+    match image_store.save(&user.user_id, &file_name, data.to_vec()).await {
+        Ok(image_id) => {
+            tracing::info!("Image saved successfully with ID: {}", image_id);
+            Ok((StatusCode::OK, image_id.to_string()).into_response())
+        }
+        Err(e) => {
+            tracing::error!("Failed to save image: {}", e);
+            Ok((StatusCode::INTERNAL_SERVER_ERROR, "Failed to process image").into_response())
+        }
+    }
 }

--- a/gitjobs-server/templates/macros.html
+++ b/gitjobs-server/templates/macros.html
@@ -149,9 +149,9 @@
       </div>
 
       <div class="flex flex-col justify-between self-stretch">
-        <p class="form-legend">
-          Images must be at least 400x400, preferably in square format. Formats supported: SVG, PNG, JPEG, GIF, WEBP and TIFF.
-        </p>
+      <p class="form-legend">
+        Images must be at least 400x400, preferably in square format. Maximum file size: 2MB. Formats supported: SVG, PNG, JPEG, GIF, WEBP and TIFF.
+      </p>
 
         <div class="flex items-center gap-x-3">
           {# Input file #}
@@ -205,7 +205,16 @@
           placeholderImage.classList.add('hidden');
           cleanImage.removeAttribute('disabled');
         } else {
-          showErrorAlert('Something went wrong adding the image, please try again later.');
+          // Show specific error message from server if available
+          let errorMessage = 'Something went wrong adding the image, please try again later.';
+          if (e.detail.xhr.response && e.detail.xhr.response.trim()) {
+            errorMessage = e.detail.xhr.response;
+          } else if (e.detail.xhr.status === 413 || e.detail.xhr.status === 413) {
+            errorMessage = 'File is too large. Please choose an image smaller than 2MB.';
+          } else if (e.detail.xhr.status === 400) {
+            errorMessage = 'Invalid file format. Please use JPG, PNG, GIF, WEBP, TIFF, or SVG.';
+          }
+          showErrorAlert(errorMessage);
         }
       });
 


### PR DESCRIPTION
## Problem
I was experiencing a 400 error when attempting to upload profile pictures, specifically with a 3MB JPEG file. The error was coming from the `/dashboard/images` endpoint with minimal error information.

1. **Total Guess: Axum's default multipart body limit** was being exceeded (default is typically 2MB)
2. **Poor error handling** in the upload handler provided no useful feedback to users
3. **No file size validation** on the application level
4. **No user-facing guidance** about file size limits

Changes Made

1. Enhanced Error Handling (`gitjobs-server/src/handlers/img.rs`)
2. Increased Server Body Limit (`gitjobs-server/src/router.rs`)
3. Improved Frontend Error Handling (`gitjobs-server/templates/macros.html`)

